### PR TITLE
Checkout cart

### DIFF
--- a/spec/features/cart/add_item_to_cart_spec.rb
+++ b/spec/features/cart/add_item_to_cart_spec.rb
@@ -1,43 +1,22 @@
 require "spec_helper"
 
 feature "Add item to cart" do
-  context "Add item from item page" do
-    before do
-      visit "/index.php?id_product=1&controller=product"
-    end
+  before do
+    # Hardcoding for now
+    visit "/index.php?id_product=1&controller=product"
+  end
 
+  context "add item from item page" do
     it "can add item with default values to cart" do
       click_button "Add to cart"
       expect(page).to have_content "Product successfully added to your shopping cart"
-      expect(page).to have_content "Continue shopping"
-      expect(page).to have_content "Proceed to checkout"
     end
   end
 
-  xit "can go to checkout" do
-    add_default_item()
-    #expect(page).to have_content "Product successfully added to your shopping cart"
-    within("#layer_cart") do
-      #find(".button-medium") #works
-      #expect(page).to have_css(".button-medium") #works
-      click_button("Proceed to checkout") #fails, can't find nondisabled button
-      #binding.pry
-    end
+  it "can add item and go to checkout" do
+    click_button "Add to cart"
+    # Element is styled to look a button, but is actually a link
+    click_link "Proceed to checkout"
+    expect(page).to have_content "SHOPPING-CART SUMMARY"
   end
-
-  # click_button ("Proceed to checkout", visible: :all) #fails
-  # expect(page).to have_content "SHOPPING-CART SUMMARY" #fails
-  #binding.pry
-
-  #works - can find success message but not go to checkout button :(
-  it "can go to checkout" do
-    add_default_item
-    expect(page).to have_content "Product successfully added to your shopping cart"
-  end
-end
-
-#TODO - decide whether best to have visit link in before block or here
-def add_default_item
-  visit "/index.php?id_product=1&controller=product"
-  click_button "Add to cart"
 end

--- a/spec/features/cart/add_item_to_cart_spec.rb
+++ b/spec/features/cart/add_item_to_cart_spec.rb
@@ -13,4 +13,31 @@ feature "Add item to cart" do
       expect(page).to have_content "Proceed to checkout"
     end
   end
+
+  xit "can go to checkout" do
+    add_default_item()
+    #expect(page).to have_content "Product successfully added to your shopping cart"
+    within("#layer_cart") do
+      #find(".button-medium") #works
+      #expect(page).to have_css(".button-medium") #works
+      click_button("Proceed to checkout") #fails, can't find nondisabled button
+      #binding.pry
+    end
+  end
+
+  # click_button ("Proceed to checkout", visible: :all) #fails
+  # expect(page).to have_content "SHOPPING-CART SUMMARY" #fails
+  #binding.pry
+
+  #works - can find success message but not go to checkout button :(
+  it "can go to checkout" do
+    add_default_item
+    expect(page).to have_content "Product successfully added to your shopping cart"
+  end
+end
+
+#TODO - decide whether best to have visit link in before block or here
+def add_default_item
+  visit "/index.php?id_product=1&controller=product"
+  click_button "Add to cart"
 end


### PR DESCRIPTION
- Example for going to checkout (order summary page) from item page
- Removed unnecessary assertions from add item to cart example
